### PR TITLE
Add generative AI config and Gemini support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # OpenAI API key
-openai_config.json
+generativeAi_config.json
 reverie/backend_server/utils.py
 environment/frontend_server/temp_storage/curr_sim_code.json
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Note: If you change the environment name from `simulacra`, you'll need to update
 ```
 
 
-### Step 2. OpenAI Config
+### Step 2. Generative AI Config
 
-Create a file called `openai_config.json` in the root directory.
+Create a file called `generativeAi_config.json` in the root directory.
 
 OpenAI example:
 ```json
@@ -85,6 +85,9 @@ To use Gemini, set your config as follows:
   "client": "gemini",
   "model": "gemini-1.5-pro-latest",  # or another Gemini model
   "model-key": "<GEMINI-API-KEY>",
+  "embeddings-client": "gemini",
+  "embeddings": "models/embedding-001",
+  "embeddings-key": "<GEMINI-API-KEY>",
   ...
 }
 ```

--- a/reverie/backend_server/persona/prompt_template/common.py
+++ b/reverie/backend_server/persona/prompt_template/common.py
@@ -9,9 +9,12 @@ import os
 from pathlib import Path
 from pydantic import BaseModel, field_validator
 
-config_path = Path("../../openai_config.json")
+config_path = Path("../../generativeAi_config.json")
 with open(config_path, "r") as f:
-  openai_config = json.load(f)
+  generative_ai_config = json.load(f)
+
+# Backwards compatibility
+openai_config = generative_ai_config
 
 
 def get_prompt_file_path(curr_file):

--- a/reverie/backend_server/persona/prompt_template/gpt_structure.py
+++ b/reverie/backend_server/persona/prompt_template/gpt_structure.py
@@ -19,9 +19,12 @@ try:
 except ImportError:
     genai = None
 
-config_path = Path("../../openai_config.json")
+config_path = Path("../../generativeAi_config.json")
 with open(config_path, "r") as f:
-  openai_config = json.load(f) 
+  generative_ai_config = json.load(f)
+
+# Backwards compatibility
+openai_config = generative_ai_config
 
 client = OpenAI(api_key=openai_api_key)
 
@@ -96,7 +99,7 @@ elif openai_config["client"] == "gemini":
 else:
   raise ValueError("Invalid client")
 
-if openai_config["embeddings-client"] == "azure":  
+if openai_config["embeddings-client"] == "azure":
   embeddings_client = setup_client("azure", {
     "endpoint": openai_config["embeddings-endpoint"],
     "key": openai_config["embeddings-key"],
@@ -104,6 +107,8 @@ if openai_config["embeddings-client"] == "azure":
   })
 elif openai_config["embeddings-client"] == "openai":
   embeddings_client = setup_client("openai", { "key": openai_config["embeddings-key"] })
+elif openai_config["embeddings-client"] == "gemini":
+  embeddings_client = setup_client("gemini", { "key": openai_config["embeddings-key"] })
 else:
   raise ValueError("Invalid embeddings client")
 
@@ -570,9 +575,18 @@ def get_embedding(text, model=openai_config["embeddings"]):
   text = text.replace("\n", " ")
   if not text:
     text = "this is blank"
-  response = embeddings_client.embeddings.create(input=[text], model=model)
-  cost_logger.update_cost(response=response, input_cost=openai_config["embeddings-costs"]["input"], output_cost=openai_config["embeddings-costs"]["output"])
-  return response.data[0].embedding
+  if openai_config["embeddings-client"] == "gemini":
+    response = genai.embed_content(model=model, content=text)
+    embedding = response["embedding"]
+  else:
+    response = embeddings_client.embeddings.create(input=[text], model=model)
+    embedding = response.data[0].embedding
+  cost_logger.update_cost(
+    response=response,
+    input_cost=openai_config["embeddings-costs"]["input"],
+    output_cost=openai_config["embeddings-costs"]["output"],
+  )
+  return embedding
 
 # def get_embedding(documents):
 #   api_url = "http://<instance-ip>:8000/embed"


### PR DESCRIPTION
## Summary
- ignore `generativeAi_config.json` instead of `openai_config.json`
- document new `generativeAi_config.json` setup and Gemini support
- read `generativeAi_config.json` in prompt template code
- support Gemini embeddings in GPT helpers

## Testing
- `ruff check` *(fails: unrecognized subcommand or lint errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe8ea7b9c8322af68f5277df767eb